### PR TITLE
feat: testing-library should a devDependencies

### DIFF
--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -1,10 +1,12 @@
 {
   "package": {
     "dependencies": {
-      "@testing-library/jest-dom": "^5.11.4",
-      "@testing-library/react": "^11.1.0",
-      "@testing-library/user-event": "^12.1.10",
       "web-vitals": "^1.0.1"
+    },
+    "devDependencies": {
+      "@testing-library/jest-dom": "^5.11.10",
+      "@testing-library/react": "^11.2.6",
+      "@testing-library/user-event": "^12.8.3"
     },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]


### PR DESCRIPTION
I saw this when code reviewing someone else PR and notice packages, which are used for testing, as part of the usual dependencies. I moved: `testing-library/jest-dom`, `testing-library/react`and `testing-library/user-event` are all suggested to be installed as a dev dependencies.